### PR TITLE
Update mcafee_detect.ps1

### DIFF
--- a/mcafee_detect.ps1
+++ b/mcafee_detect.ps1
@@ -16,14 +16,15 @@ $regPaths = @(
     "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
     "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
 )
-foreach ($regPath in $regPaths) {
-    if (Test-Path $regPath) {
-        Get-ChildItem -Path $regPath -ErrorAction SilentlyContinue | ForEach-Object {
-            $displayName = $_.GetValue("DisplayName")
-            if ($displayName -and ($displayName -like "*McAfee*")) {
-                Write-Host "Detected registry entry: $displayName"
-                $foundRegistry = $true
-            }
+foreach ($rp in $regPaths) {
+    if (Test-Path $rp) {
+        $matches = Get-ItemProperty -Path $rp -ErrorAction SilentlyContinue | Where-Object { 
+            $_.DisplayName -like "*McAfee*"
+        }
+        
+        foreach ($match in $matches) {
+            Write-Log ("Detected registry entry: {0}" -f $match.DisplayName) "DEBUG"
+            $foundRegistry = $true
         }
     }
 }


### PR DESCRIPTION
I was looking into testing the detection script and was wondering about the extra iteration, putting extra load on the script. In an Intune detection it would be good if it is as light as possible, and this should avoid unnecessary iterations through Get-ChildItem for all

Just drafting to make sure it can still pull name