### PR TITLE
W uez rs patch 1

### DIFF
--- a/mcafee_detect.ps1
+++ b/mcafee_detect.ps1
@@ -16,14 +16,14 @@ $regPaths = @(
     "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
     "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
 )
-foreach ($regPath in $regPaths) {
-    if (Test-Path $regPath) {
-        Get-ChildItem -Path $regPath -ErrorAction SilentlyContinue | ForEach-Object {
-            $displayName = $_.GetValue("DisplayName")
-            if ($displayName -and ($displayName -like "*McAfee*")) {
-                Write-Host "Detected registry entry: $displayName"
-                $foundRegistry = $true
-            }
+foreach ($rp in $regPaths) {
+    if (Test-Path $rp) {
+        $matches = Get-ItemProperty -Path $rp -ErrorAction SilentlyContinue | Where-Object { 
+            $_.DisplayName -like "*McAfee*"
+        }
+        
+        foreach ($match in $matches) {
+            Write-Host "Detected registry entry: $($match.DisplayName)"
         }
     }
 }

--- a/mcafee_detect.ps1
+++ b/mcafee_detect.ps1
@@ -24,6 +24,7 @@ foreach ($rp in $regPaths) {
         
         foreach ($match in $matches) {
             Write-Host "Detected registry entry: $($match.DisplayName)"
+            $foundRegistry = $true
         }
     }
 }


### PR DESCRIPTION
Avoids Unnecessary Iteration – Get-ItemProperty retrieves all subkeys at once, reducing the need for Get-ChildItem, Where-Object ensures only relevant registry entries are processed. Lighter script for Detection